### PR TITLE
basic schedule page done

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -9,6 +9,7 @@
     "@testing-library/user-event": "^13.5.0",
     "dayjs": "^1.11.0",
     "react": "^18.0.0",
+    "react-calendar": "^3.7.0",
     "react-dom": "^18.0.0",
     "react-icons": "^4.3.1",
     "react-router-dom": "^5.2.0",

--- a/client/src/Hooks/DataContext.js
+++ b/client/src/Hooks/DataContext.js
@@ -5,6 +5,7 @@ export const DataContext = createContext();
 
 export const DataProvider = ({ children }) => {
   const [games, setGames] = useState(null);
+  const [gamesSched, setGamesSched] = useState(null)
   const [gameId, setGameId] = useState(null);
   const [odds, setOdds] = useState(null);
   const [newsItems, setNewsItems] = useState(null);
@@ -44,6 +45,20 @@ export const DataProvider = ({ children }) => {
       .then((data) => setGames(data.data));
   };
 
+  const getGamesSched = (date) => {
+    const start = date.format("YYYY-MM-DD");
+    const end = date.add(7, "day").format("YYYY-MM-DD");
+        fetch(`https://www.balldontlie.io/api/v1/games?per_page=100&start_date=${start}&end_date=${end}`)
+        .then((res) => res.json())
+        .then((data) => {
+          let newArr = [];
+          data.data.forEach((game) => {
+            newArr.push(game);
+          });
+          setGamesSched(newArr);
+        })
+  }
+
   // fetching game and odds data on load, everything else on demand
   useEffect(() => {
     getGames();
@@ -59,6 +74,7 @@ export const DataProvider = ({ children }) => {
     <DataContext.Provider
       value={{
         games,
+        gamesSched,
         gameId,
         odds,
         newsItems,
@@ -70,6 +86,7 @@ export const DataProvider = ({ children }) => {
         getStandings,
         getOdds,
         getGames,
+        getGamesSched,
       }}
     >
       {children}

--- a/client/src/Schedule/CalendarModal.js
+++ b/client/src/Schedule/CalendarModal.js
@@ -1,0 +1,49 @@
+import dayjs from "dayjs";
+import Calendar from "react-calendar";
+import styled from "styled-components";
+
+const CalendarModal = ({ setModal, getGamesSched, setDate }) => {
+  const handleDateClick = (day) => {
+    let date = dayjs(day, "ddd MMM DD YYYY");
+    setDate(date);
+    getGamesSched(date);
+    setModal(null);
+  };
+
+  return (
+    <Modal onClick={() => setModal(null)}>
+      <Wrapper onClick={(ev) => ev.stopPropagation()}>
+        <Calendar
+          minDate={new Date(2021, 9, 1)}
+          maxDate={new Date(2022, 5, 30)}
+          minDetail={"month"}
+          next2Label={null}
+          prev2Label={null}
+          onChange={(day) => handleDateClick(day)}
+        />
+      </Wrapper>
+    </Modal>
+  );
+};
+
+const Modal = styled.div`
+  position: fixed;
+  top: 0;
+  right: 0;
+  left: 0;
+  bottom: 0;
+  display: flex;
+  align-items: baseline;
+  justify-content: center;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 2;
+`;
+
+const Wrapper = styled.div`
+  margin-top: 10rem;
+  width: 20rem;
+  background-color: var(--base-color);
+  transition: all 0.3s;
+`;
+
+export default CalendarModal;

--- a/client/src/Schedule/Schedule.js
+++ b/client/src/Schedule/Schedule.js
@@ -1,7 +1,110 @@
+import dayjs from "dayjs";
+import { useEffect, useState, useContext } from "react";
 import styled from "styled-components";
 
+import { DataContext } from "../Hooks/DataContext";
+import Loading from "../Loading";
+import { IoCalendarOutline } from "react-icons/io5";
+import CalendarModal from "./CalendarModal";
+
 const Schedule = () => {
-  return <div>Schedule</div>;
+  const { gamesSched, getGamesSched } = useContext(DataContext);
+  const [modal, setModal] = useState(false)
+  const [date, setDate] = useState(dayjs());
+
+  if (!gamesSched) {
+    getGamesSched(dayjs());
+    return <Loading />;
+  }
+
+  let week = [];
+  let day = date;
+  for (let i = 0; i < 7; i++) {
+    week.push(day.format("YYYY-MM-DD"));
+    day = day.add(1, "day");
+  }
+
+  return (
+    <Wrapper>
+      {(modal) && <CalendarModal setModal={setModal} getGamesSched={getGamesSched} setDate={setDate} />}
+      <Container>
+        <Header>
+          <h1>Schedule</h1>
+          <IoCalendarOutline className="icon" onClick={()=> setModal(true)} />
+        </Header>
+        {week.map((day) => {
+          return (
+            <>
+              <h2>{dayjs(day, "YYYY-MM-DD").format("ddd MMM DD")}</h2>
+              {gamesSched.filter((game) => game.date.slice(0, 10) === day)
+                .length > 0 ? (
+                gamesSched
+                  .filter((game) => game.date.slice(0, 10) === day)
+                  .map((game) => {
+                    return (
+                      <GameDiv key={game.id}>
+                        <NameDiv>
+                          <div className="city">{game.home_team.full_name}</div>
+                          <div> VS </div>
+                          <div className="city">{game.visitor_team.full_name}</div>
+                        </NameDiv>
+                        <ScoreDiv>
+                          <div className="score">{game.home_team_score}</div>
+                          <div className="score">-{game.visitor_team_score}</div>
+                        </ScoreDiv>
+                      </GameDiv>
+                    );
+                  })
+              ) : (
+                <span>No games scheduled</span>
+              )}
+            </>
+          );
+        })}
+      </Container>
+    </Wrapper>
+  );
 };
+
+const Wrapper = styled.div`
+  width: 100%;
+`;
+
+const Container = styled.div`
+  width: 35rem;
+`;
+
+const Header = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  .icon {
+    width: 1.5rem;
+    height: 1.5rem;
+    margin: 1rem;
+    cursor: pointer;
+  }
+`;
+
+const GameDiv = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  padding: 0 1rem;
+`;
+
+const NameDiv = styled.div`
+  display: flex;
+  > div {
+    width: 3rem;
+  }
+  .city {
+    width: 13rem;
+  }
+`;
+
+const ScoreDiv = styled.div`
+  display: flex;
+`;
 
 export default Schedule;

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2970,6 +2970,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@wojtekmaj/date-utils@npm:^1.0.2":
+  version: 1.0.3
+  resolution: "@wojtekmaj/date-utils@npm:1.0.3"
+  checksum: 70b7152160529295319ead97e070f85a50c0eab7973b5845e3a58eab9b0c999023975d2739b5e2a059d27b108ce7cdbf14da99737d6fa3e3822d4dafb76b06f0
+  languageName: node
+  linkType: hard
+
 "@xtuc/ieee754@npm:^1.2.0":
   version: 1.2.0
   resolution: "@xtuc/ieee754@npm:1.2.0"
@@ -4052,6 +4059,7 @@ __metadata:
     "@testing-library/user-event": ^13.5.0
     dayjs: ^1.11.0
     react: ^18.0.0
+    react-calendar: ^3.7.0
     react-dom: ^18.0.0
     react-icons: ^4.3.1
     react-router-dom: ^5.2.0
@@ -6114,6 +6122,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"get-user-locale@npm:^1.2.0":
+  version: 1.4.0
+  resolution: "get-user-locale@npm:1.4.0"
+  dependencies:
+    lodash.once: ^4.1.1
+  checksum: d27a6cf7b1aacdec1786c6877511efc956eb17810e10c55a408753af38f13b5d854f3a0033320f94a6046e95d3c0fc2248c950aeecfc181353599facd344b7e4
+  languageName: node
+  linkType: hard
+
 "glob-parent@npm:^5.1.2, glob-parent@npm:~5.1.2":
   version: 5.1.2
   resolution: "glob-parent@npm:5.1.2"
@@ -7876,6 +7893,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash.once@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "lodash.once@npm:4.1.1"
+  checksum: d768fa9f9b4e1dc6453be99b753906f58990e0c45e7b2ca5a3b40a33111e5d17f6edf2f768786e2716af90a8e78f8f91431ab8435f761fef00f9b0c256f6d245
+  languageName: node
+  linkType: hard
+
 "lodash.sortby@npm:^4.7.0":
   version: 4.7.0
   resolution: "lodash.sortby@npm:4.7.0"
@@ -8011,6 +8035,13 @@ __metadata:
   dependencies:
     fs-monkey: 1.0.3
   checksum: 6d2f49d447d1be24ff9c747618933784eeb059189bc6a0d77b7a51c7daf06e2d3a74674a2e2ff1520e2c312bf91e719ed37144cf05087379b3ba0aef0b6aa062
+  languageName: node
+  linkType: hard
+
+"merge-class-names@npm:^1.1.1":
+  version: 1.4.2
+  resolution: "merge-class-names@npm:1.4.2"
+  checksum: 569c333ab0d7fa1e06ae6e637d58e0d4623d7b165ea78d085c1bbd042568d8793bb7ce54ec55580679416046b11fc6eaf4956d68d19964cb320edc034e182c1d
   languageName: node
   linkType: hard
 
@@ -9775,7 +9806,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prop-types@npm:^15.6.2, prop-types@npm:^15.8.1":
+"prop-types@npm:^15.6.0, prop-types@npm:^15.6.2, prop-types@npm:^15.8.1":
   version: 15.8.1
   resolution: "prop-types@npm:15.8.1"
   dependencies:
@@ -9886,6 +9917,21 @@ __metadata:
     regenerator-runtime: ^0.13.9
     whatwg-fetch: ^3.6.2
   checksum: 1bb031080af15397d6eb9c69a0c2e93799991f7197a086e4409ba719398f1256b542a3d6c9a34673d516c684eef3e8226c99b335982593851f58f65f6e43571b
+  languageName: node
+  linkType: hard
+
+"react-calendar@npm:^3.7.0":
+  version: 3.7.0
+  resolution: "react-calendar@npm:3.7.0"
+  dependencies:
+    "@wojtekmaj/date-utils": ^1.0.2
+    get-user-locale: ^1.2.0
+    merge-class-names: ^1.1.1
+    prop-types: ^15.6.0
+  peerDependencies:
+    react: ^16.3.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.3.0 || ^17.0.0 || ^18.0.0
+  checksum: 368084515bdbc59dddf1a0e367c6bb49e9b9efdc1d01343afeeb412feb52d89b88ac6b09378433cdb3716557ff2cf56751f11183ecd99a5df2a5c48b1691e33d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- created a simple schedule page that displays all the games in the next 7 days, sorted by day
- used react-calendar to add a pop-up calendar modal, that lets you select any date (within the current season) and show the games from that week